### PR TITLE
Fix mobile horizontal overflow on /cc/about and similar pages

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,7 @@
 }
 
 html {
+  overflow-x: hidden;
   color: var(--text);
   background:
     radial-gradient(circle at top right, rgba(252, 246, 232, 0.96), rgba(247, 240, 226, 0.92) 46%, rgba(242, 233, 215, 0.96)),
@@ -29,6 +30,7 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
+  overflow-x: hidden;
   background-color: var(--bg);
   background-image:
     radial-gradient(circle at 15% 10%, rgba(255, 255, 255, 0.24), transparent 16%),
@@ -820,6 +822,10 @@ main.shell {
 
   .footer-meta {
     text-align: left;
+  }
+
+  .with-sidebar {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
The sidebar grid column stayed at a fixed 260px even though its
sidebar-panel content is hidden, and decorative hero elements bled
past the container edge, causing horizontal scrolling on phones.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ena2vcf3iLpf2oywH6sFCQ